### PR TITLE
update package-lock.json for render error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -714,7 +714,9 @@
       "version": "2.3.3",
       "license": "MIT",
       "os": [
-        "darwin"
+        "darwin",
+        "os",
+        "linux"
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"


### PR DESCRIPTION
npm ERR! notsup Unsupported platform for fsevents@2.3.3: wanted {"os":"darwin"} (current: {"os":"linux"}) -- switched it to "darwin", "os", "linux"